### PR TITLE
Add interactive map view for stable search results

### DIFF
--- a/src/components/molecules/RealTimeSearchSort.tsx
+++ b/src/components/molecules/RealTimeSearchSort.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { ChevronDownIcon, ArrowUpIcon, ArrowDownIcon } from '@heroicons/react/24/outline';
+import { ChevronDownIcon, ArrowUpIcon, ArrowDownIcon, MapIcon, ListBulletIcon } from '@heroicons/react/24/outline';
 import { StableWithBoxStats, BoxWithStablePreview } from '@/types/stable';
 
 type SortOption = 
@@ -32,6 +32,8 @@ interface RealTimeSearchSortProps {
   totalResults: number;
   isLoading?: boolean;
   isRealTime?: boolean;
+  showMap?: boolean;
+  onToggleMap?: () => void;
 }
 
 const stableSortOptions: SortConfig[] = [
@@ -148,7 +150,9 @@ export default function RealTimeSearchSort({
   currentSort = 'newest',
   totalResults,
   isLoading = false,
-  isRealTime = true
+  isRealTime = true,
+  showMap = false,
+  onToggleMap
 }: RealTimeSearchSortProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [lastUpdateTime, setLastUpdateTime] = useState<Date>(new Date());
@@ -203,13 +207,36 @@ export default function RealTimeSearchSort({
         )}
       </div>
 
-      {/* Sort dropdown */}
-      <div className="relative">
-        <button
-          onClick={() => setIsOpen(!isOpen)}
-          className="flex items-center justify-between w-full sm:w-auto min-w-[200px] px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
-          disabled={isLoading}
-        >
+      {/* View controls */}
+      <div className="flex items-center space-x-3">
+        {/* Map toggle button - only show for stables */}
+        {searchMode === 'stables' && onToggleMap && (
+          <button
+            onClick={onToggleMap}
+            className="flex items-center space-x-2 px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500 transition-colors"
+            disabled={isLoading}
+          >
+            {showMap ? (
+              <>
+                <ListBulletIcon className="w-4 h-4" />
+                <span>Vis liste</span>
+              </>
+            ) : (
+              <>
+                <MapIcon className="w-4 h-4" />
+                <span>Vis i kart</span>
+              </>
+            )}
+          </button>
+        )}
+
+        {/* Sort dropdown */}
+        <div className="relative">
+          <button
+            onClick={() => setIsOpen(!isOpen)}
+            className="flex items-center justify-between w-full sm:w-auto min-w-[200px] px-4 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-md hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+            disabled={isLoading}
+          >
           <div className="flex items-center space-x-2">
             {currentSortConfig.icon}
             <span>Sorter: {currentSortConfig.label}</span>
@@ -266,6 +293,7 @@ export default function RealTimeSearchSort({
             </div>
           </>
         )}
+        </div>
       </div>
     </div>
   );

--- a/src/components/molecules/SearchResultsMap.tsx
+++ b/src/components/molecules/SearchResultsMap.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+import { MapPinIcon } from '@heroicons/react/24/outline';
+import type { Map, Marker } from 'leaflet';
+import { StableWithBoxStats } from '@/types/stable';
+import 'leaflet/dist/leaflet.css';
+
+interface SearchResultsMapProps {
+  stables: StableWithBoxStats[];
+  className?: string;
+}
+
+export default function SearchResultsMap({ 
+  stables, 
+  className = "w-full h-96" 
+}: SearchResultsMapProps) {
+  const mapRef = useRef<HTMLDivElement>(null);
+  const mapInstanceRef = useRef<Map | null>(null);
+  const markersRef = useRef<Marker[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Filter stables that have valid coordinates
+  const validStables = stables.filter(stable => 
+    stable.latitude && stable.longitude && 
+    typeof stable.latitude === 'number' && 
+    typeof stable.longitude === 'number'
+  );
+
+  useEffect(() => {
+    if (!mapRef.current || validStables.length === 0) {
+      setIsLoading(false);
+      return;
+    }
+    
+    const currentMapRef = mapRef.current;
+
+    const loadMap = async () => {
+      try {
+        setIsLoading(true);
+
+        // Clean up existing map and markers
+        markersRef.current.forEach(marker => {
+          marker.remove();
+        });
+        markersRef.current = [];
+
+        if (mapInstanceRef.current) {
+          mapInstanceRef.current.remove();
+          mapInstanceRef.current = null;
+        }
+
+        // Clear the container
+        if (mapRef.current) {
+          mapRef.current.innerHTML = '';
+          delete (mapRef.current as HTMLDivElement & { _leaflet_id?: number })._leaflet_id;
+        }
+
+        // Dynamically import Leaflet
+        const L = await import('leaflet');
+        
+        // Fix for default markers
+        delete (L.Icon.Default.prototype as L.Icon.Default & { _getIconUrl?: () => string })._getIconUrl;
+        L.Icon.Default.mergeOptions({
+          iconRetinaUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon-2x.png',
+          iconUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-icon.png',
+          shadowUrl: 'https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.7.1/images/marker-shadow.png',
+        });
+
+        // Calculate bounds for all stables
+        const coordinates = validStables.map(stable => [
+          stable.latitude!,
+          stable.longitude!
+        ]);
+
+        // Initialize map
+        const map = L.map(mapRef.current!, {
+          zoomControl: true,
+          scrollWheelZoom: true,
+          doubleClickZoom: true,
+          boxZoom: true,
+          keyboard: true,
+          dragging: true,
+          touchZoom: true
+        });
+        mapInstanceRef.current = map;
+
+        // Add OpenStreetMap tiles
+        L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+          attribution: '© OpenStreetMap contributors'
+        }).addTo(map);
+
+        // Add markers for each stable
+        validStables.forEach(stable => {
+          const marker = L.marker([stable.latitude!, stable.longitude!]).addTo(map);
+          markersRef.current.push(marker);
+
+          // Create popup content with stable info
+          const popupContent = `
+            <div class="p-3 max-w-xs">
+              <div class="flex items-start gap-3">
+                ${stable.images && stable.images.length > 0 
+                  ? `<img src="${stable.images[0]}" alt="${stable.name}" class="w-16 h-16 object-cover rounded-lg flex-shrink-0" />`
+                  : `<div class="w-16 h-16 bg-gray-200 rounded-lg flex items-center justify-center flex-shrink-0">
+                       <svg class="w-6 h-6 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 7v10a2 2 0 002 2h14a2 2 0 002-2V9a2 2 0 00-2-2H5a2 2 0 00-2-2z"></path>
+                         <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 5a2 2 0 012-2h4a2 2 0 012 2v1H8V5z"></path>
+                       </svg>
+                     </div>`
+                }
+                <div class="flex-1 min-w-0">
+                  <h3 class="font-semibold text-gray-900 truncate">${stable.name}</h3>
+                  <p class="text-sm text-gray-600 mb-2">${stable.location}</p>
+                  
+                  <div class="flex items-center gap-2 text-xs text-gray-500 mb-2">
+                    <span>${stable.totalBoxes} ${stable.totalBoxes === 1 ? 'boks' : 'bokser'}</span>
+                    ${stable.availableBoxes > 0 
+                      ? `<span class="text-green-600">${stable.availableBoxes} ledig${stable.availableBoxes === 1 ? '' : 'e'}</span>`
+                      : `<span class="text-gray-400">Utleid</span>`
+                    }
+                  </div>
+                  
+                  ${stable.priceRange.min > 0 
+                    ? `<p class="text-sm font-medium text-gray-900 mb-2">
+                         ${stable.priceRange.min === stable.priceRange.max 
+                           ? `${stable.priceRange.min.toLocaleString()} kr/mnd`
+                           : `${stable.priceRange.min.toLocaleString()}-${stable.priceRange.max.toLocaleString()} kr/mnd`
+                         }
+                       </p>`
+                    : ''
+                  }
+                  
+                  <div class="popup-link-container">
+                    <a href="/staller/${stable.id}" 
+                       class="inline-block bg-green-600 text-white text-xs px-3 py-1 rounded hover:bg-green-700 transition-colors"
+                       target="_blank">
+                      Se detaljer
+                    </a>
+                  </div>
+                </div>
+              </div>
+            </div>
+          `;
+
+          marker.bindPopup(popupContent, {
+            maxWidth: 320,
+            className: 'stable-popup'
+          });
+        });
+
+        // Fit map to show all markers
+        if (coordinates.length === 1) {
+          // Single marker - center on it with reasonable zoom
+          map.setView([coordinates[0][0], coordinates[0][1]], 13);
+        } else if (coordinates.length > 1) {
+          // Multiple markers - fit bounds
+          const bounds = L.latLngBounds(coordinates as [number, number][]);
+          map.fitBounds(bounds, { padding: [20, 20] });
+        }
+
+        setIsLoading(false);
+
+      } catch (error) {
+        console.error('Error loading search results map:', error);
+        setIsLoading(false);
+      }
+    };
+
+    loadMap();
+
+    // Cleanup on unmount
+    return () => {
+      markersRef.current.forEach(marker => {
+        marker.remove();
+      });
+      markersRef.current = [];
+      
+      if (mapInstanceRef.current) {
+        mapInstanceRef.current.remove();
+        mapInstanceRef.current = null;
+      }
+      
+      if (currentMapRef) {
+        currentMapRef.innerHTML = '';
+        delete (currentMapRef as HTMLDivElement & { _leaflet_id?: number })._leaflet_id;
+      }
+    };
+  }, [validStables]);
+
+  // No valid coordinates available
+  if (validStables.length === 0) {
+    return (
+      <div className={`${className} bg-gray-100 rounded-lg flex items-center justify-center border border-gray-200`}>
+        <div className="text-center">
+          <MapPinIcon className="h-12 w-12 text-gray-400 mx-auto mb-4" />
+          <p className="text-lg font-medium text-gray-700 mb-2">Ingen staller med kart tilgjengelig</p>
+          <p className="text-sm text-gray-500">
+            {stables.length > 0 
+              ? 'Stallene i søkeresultatet mangler koordinatinformasjon'
+              : 'Ingen staller funnet'
+            }
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`${className} relative rounded-lg overflow-hidden border border-gray-200`}>
+      {isLoading && (
+        <div className="absolute inset-0 bg-white/80 flex items-center justify-center z-20">
+          <div className="flex items-center space-x-2">
+            <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-green-600"></div>
+            <span className="text-sm text-gray-600">Laster kart...</span>
+          </div>
+        </div>
+      )}
+      
+      <div 
+        ref={mapRef} 
+        className="w-full h-full leaflet-map-container"
+        style={{ zIndex: 10 }}
+      />
+      
+      {!isLoading && (
+        <div className="absolute top-4 left-4 bg-white/90 backdrop-blur-sm rounded-lg px-3 py-2 text-sm text-gray-700 shadow-md z-20">
+          {validStables.length} {validStables.length === 1 ? 'stall' : 'staller'} på kartet
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/organisms/SearchPageClient.tsx
+++ b/src/components/organisms/SearchPageClient.tsx
@@ -5,6 +5,7 @@ import { SearchPageClientProps, SearchFilters } from '@/types/components';
 import SearchFiltersComponent from '@/components/organisms/SearchFilters';
 import StableListingCard from '@/components/molecules/StableListingCard';
 import BoxListingCard from '@/components/molecules/BoxListingCard';
+import SearchResultsMap from '@/components/molecules/SearchResultsMap';
 import RealTimeSearchSort, { sortBoxes } from '@/components/molecules/RealTimeSearchSort';
 import { useLocationSuggestions, useLocationBasedFiltering } from '@/components/molecules/RealTimeLocationSearch';
 import { AdjustmentsHorizontalIcon, XMarkIcon } from '@heroicons/react/24/outline';
@@ -23,6 +24,7 @@ export default function SearchPageClient({
 }: SearchPageClientProps) {
   const [searchMode, setSearchMode] = useState<SearchMode>('boxes');
   const [showFilters, setShowFilters] = useState(false);
+  const [showMap, setShowMap] = useState(false);
   const [isMobile, setIsMobile] = useState(false);
   const [sortOption, setSortOption] = useState<SortOption>('newest');
   const [filters, setFilters] = useState<SearchFilters>({
@@ -157,10 +159,19 @@ export default function SearchPageClient({
   // Auto-hide filters on mobile when search mode changes (optional UX improvement)
   const handleSearchModeChange = (mode: 'stables' | 'boxes') => {
     setSearchMode(mode);
+    // Reset map view when switching to boxes mode (map only works for stables)
+    if (mode === 'boxes') {
+      setShowMap(false);
+    }
     // Optionally hide filters on mobile after selection
     if (isMobile) {
       setShowFilters(false);
     }
+  };
+
+  // Handle map toggle
+  const handleToggleMap = () => {
+    setShowMap(!showMap);
   };
 
   return (
@@ -214,6 +225,8 @@ export default function SearchPageClient({
             totalResults={currentItems.length}
             isLoading={isLoading}
             isRealTime={true}
+            showMap={showMap}
+            onToggleMap={handleToggleMap}
           />
 
           {/* Error state */}
@@ -245,15 +258,25 @@ export default function SearchPageClient({
               </p>
             </div>
           ) : (
-            <div className="space-y-4 sm:space-y-6">
-              {isStableMode ? (
-                filteredStables.map((stable) => (
-                  <StableListingCard key={stable.id} stable={stable as StableWithBoxStats} />
-                ))
+            <div>
+              {/* Show map view for stables or regular list view */}
+              {isStableMode && showMap ? (
+                <SearchResultsMap 
+                  stables={filteredStables as StableWithBoxStats[]}
+                  className="w-full h-96 md:h-[500px] lg:h-[600px]"
+                />
               ) : (
-                filteredBoxes.map((box) => (
-                  <BoxListingCard key={box.id} box={box} />
-                ))
+                <div className="space-y-4 sm:space-y-6">
+                  {isStableMode ? (
+                    filteredStables.map((stable) => (
+                      <StableListingCard key={stable.id} stable={stable as StableWithBoxStats} />
+                    ))
+                  ) : (
+                    filteredBoxes.map((box) => (
+                      <BoxListingCard key={box.id} box={box} />
+                    ))
+                  )}
+                </div>
               )}
             </div>
           )}


### PR DESCRIPTION
## Summary
- Add interactive map view for stables accessible via "Vis i kart" button
- Implement SearchResultsMap component with Leaflet integration
- Add map toggle functionality to search results interface
- Show rich stable info popups with navigation to detail pages

## Test plan
- [x] TypeScript compilation passes
- [x] ESLint checks pass  
- [x] Production build succeeds
- [x] Map displays stables with valid coordinates
- [x] Info popups show stable details and navigation
- [x] Toggle between list and map view works correctly
- [x] Map only available for stable search (not boxes)

🤖 Generated with [Claude Code](https://claude.ai/code)