### PR TITLE
Fix Next.js image hostname configuration for Supabase storage

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -29,6 +29,20 @@ const nextConfig: NextConfig = {
         port: '',
         pathname: '/**',
       },
+      // Local Supabase Storage
+      {
+        protocol: 'http',
+        hostname: '127.0.0.1',
+        port: '54321',
+        pathname: '/storage/v1/object/public/**',
+      },
+      // Production Supabase Storage
+      {
+        protocol: 'https',
+        hostname: 'wawnmmmwkysbtexbmdwg.supabase.co',
+        port: '',
+        pathname: '/storage/v1/object/public/**',
+      },
     ],
   },
 };


### PR DESCRIPTION
## Summary
- Add support for local development Supabase storage URLs (127.0.0.1:54321)
- Add support for production Supabase storage URLs (wawnmmmwkysbtexbmdwg.supabase.co)
- Fixes "hostname not configured" error when uploading images

## Test plan
- [ ] Test image upload in local development environment
- [ ] Test image upload in production environment
- [ ] Verify images display correctly after upload

🤖 Generated with [Claude Code](https://claude.ai/code)