### PR TITLE
Fix broken stable preview button navigation

### DIFF
--- a/src/components/molecules/StableOverviewCard.tsx
+++ b/src/components/molecules/StableOverviewCard.tsx
@@ -106,7 +106,7 @@ export default function StableOverviewCard({ stable, onDelete, deleteLoading }: 
         
         <div className="flex space-x-2 ml-4">
           <button 
-            onClick={() => router.push(`/stables/${stable.id}`)}
+            onClick={() => router.push(`/staller/${stable.id}`)}
             className="p-2 text-slate-400 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-all"
             title="Forhåndsvis stall"
           >


### PR DESCRIPTION
## Summary
- Fixed broken navigation from stable preview button in dashboard
- Button was trying to navigate to `/stables/` but correct Norwegian route is `/staller/`
- Changes route from `/stables/${stable.id}` to `/staller/${stable.id}` in StableOverviewCard component

## Test plan
- [ ] Navigate to dashboard and view stable cards
- [ ] Click the eye (preview) button on any stable card
- [ ] Verify it navigates to the public stable page instead of showing 404
- [ ] Confirm stable details load correctly on the public page

🤖 Generated with [Claude Code](https://claude.ai/code)