### PR TITLE
Fix redirect after completing box advertising purchase

### DIFF
--- a/src/app/dashboard/bestill/page.tsx
+++ b/src/app/dashboard/bestill/page.tsx
@@ -79,7 +79,7 @@ function BestillPageContent() {
 
       // Show success message
       alert('Takk! Din bestilling er aktivert og du vil motta faktura på e-post.');
-      router.back();
+      router.push('/dashboard?tab=stables');
     } catch {
       // Error is handled by TanStack Query
     }


### PR DESCRIPTION
## Summary
- Fixed redirect issue after completing box advertising purchase
- Users are now properly redirected to `/dashboard?tab=stables` instead of being taken back to the advertising purchase page

## Changes
- Modified `src/app/dashboard/bestill/page.tsx` to use `router.push('/dashboard?tab=stables')` instead of `router.back()` after successful purchase completion
- This affects both single box and bulk box advertising flows since they both use the same completion page

## Test plan
- [x] Go to dashboard and select a stable with boxes
- [x] Start advertising purchase process (single or bulk)
- [x] Complete the purchase form with valid details
- [x] Verify redirect goes to `/dashboard?tab=stables` instead of back to advertising page
- [x] Confirmed fix works as expected

🤖 Generated with [Claude Code](https://claude.ai/code)