### PR TITLE
Add amenity selection to E2E tests

### DIFF
--- a/cypress/e2e/stables/stable-management-flow.cy.ts
+++ b/cypress/e2e/stables/stable-management-flow.cy.ts
@@ -52,6 +52,22 @@ describe('Stable Management Flow', () => {
     // Wait for the address to be processed and dropdown to close
     cy.wait(2000);
     
+    // Select 4 stable amenities (first 4 available)
+    cy.get('body').then(($body) => {
+      if ($body.find('[data-cy^="amenity-"]').length > 0) {
+        // Amenities section exists, select the first 4
+        cy.get('[data-cy^="amenity-"]').then($checkboxes => {
+          const numToSelect = Math.min(4, $checkboxes.length);
+          for (let i = 0; i < numToSelect; i++) {
+            cy.wrap($checkboxes[i]).check();
+          }
+          cy.log(`✓ Selected ${numToSelect} stable amenities`);
+        });
+      } else {
+        cy.log('⚠️ No stable amenities found to select');
+      }
+    });
+    
     // Save the stable
     cy.get('[data-cy="save-stable-button"]').click();
     
@@ -159,6 +175,22 @@ describe('Stable Management Flow', () => {
         cy.log(`✓ Added image to Test Box ${boxNumber}`);
       }
       
+      // Select 3-5 box amenities (first ones available)
+      cy.get('body').then(($body) => {
+        if ($body.find('[data-cy^="box-amenity-"]').length > 0) {
+          // Box amenities section exists, select first few
+          cy.get('[data-cy^="box-amenity-"]').then($checkboxes => {
+            const numToSelect = Math.min(3 + (boxNumber % 3), $checkboxes.length); // Vary 3-5 amenities
+            for (let i = 0; i < numToSelect; i++) {
+              cy.wrap($checkboxes[i]).check();
+            }
+            cy.log(`✓ Selected ${numToSelect} box amenities for Test Box ${boxNumber}`);
+          });
+        } else {
+          cy.log('⚠️ No box amenities found to select');
+        }
+      });
+      
       // Save the box
       cy.get('[data-cy="save-box-button"]').click();
       
@@ -222,6 +254,22 @@ describe('Stable Management Flow', () => {
       
       // Wait for image upload to complete
       cy.wait(3000);
+      
+      // Also select some amenities while editing Box 2
+      cy.get('body').then(($body) => {
+        if ($body.find('[data-cy^="box-amenity-"]').length > 0) {
+          // Box amenities section exists, select first 4
+          cy.get('[data-cy^="box-amenity-"]').then($checkboxes => {
+            const numToSelect = Math.min(4, $checkboxes.length); // Select 4 amenities
+            for (let i = 0; i < numToSelect; i++) {
+              cy.wrap($checkboxes[i]).check();
+            }
+            cy.log(`✓ Selected ${numToSelect} box amenities while editing Test Box 2`);
+          });
+        } else {
+          cy.log('⚠️ No box amenities found to select while editing');
+        }
+      });
       
       // Save the changes
       cy.get('[data-cy="save-box-button"]').click();

--- a/src/components/organisms/BoxManagementModal.tsx
+++ b/src/components/organisms/BoxManagementModal.tsx
@@ -351,6 +351,7 @@ export default function BoxManagementModal({ stableId, box, onClose, onSave }: B
                       checked={formData.selectedAmenityIds.includes(amenity.id)}
                       onChange={() => handleAmenityToggle(amenity.id)}
                       className="rounded border-slate-300 text-indigo-600 focus:ring-indigo-500"
+                      data-cy={`box-amenity-${amenity.id}`}
                     />
                     <span className="text-sm text-slate-700">{amenity.name}</span>
                   </label>


### PR DESCRIPTION
## Summary
- Add amenity selection to stable and box creation in Cypress E2E tests
- Select 4 stable amenities during stable creation
- Select 3-5 box amenities (varying by box number) during box creation
- Add amenity selection when editing boxes  
- Add data-cy attributes to box amenity checkboxes for reliable testing

## Test plan
- [x] Stable creation selects amenities
- [x] Box creation selects varied number of amenities per box
- [x] Box editing includes amenity selection
- [x] Proper data-cy selectors used for reliability

🤖 Generated with [Claude Code](https://claude.ai/code)