### PR TITLE
Oppdater minimumslengde for hestesalgsbeskrivelse

### DIFF
--- a/src/components/organisms/HorseSaleForm2.tsx
+++ b/src/components/organisms/HorseSaleForm2.tsx
@@ -56,7 +56,7 @@ const fieldValidators = {
   name: z.string().min(2, "Navn må være minst 2 tegn").max(100, "Navn kan ikke være mer enn 100 tegn"),
   description: z
     .string()
-    .min(1, "Beskrivelse må være minst 10 tegn")
+    .min(1, "Beskrivelse må være minst 1 tegn")
     .max(2000, "Beskrivelse kan ikke være mer enn 2000 tegn"),
   price: z
     .string()

--- a/src/lib/horse-sales-validation.ts
+++ b/src/lib/horse-sales-validation.ts
@@ -21,7 +21,7 @@ export const createHorseSaleSchema = z.object({
 
   description: z
     .string()
-    .min(1, "Beskrivelse må være minst 10 tegn")
+    .min(1, "Beskrivelse må være minst 1 tegn")
     .max(2000, "Beskrivelse kan ikke være mer enn 2000 tegn"),
 
   price: z


### PR DESCRIPTION
## Summary
- rettet beskrivelse-validering i hestesalgsskjemaet til minst 1 tegn
- justerte tilsvarende frontend-validering

## Testing
- `npm run lint`
- `RESEND_API_KEY=dummy NEXT_PUBLIC_SUPABASE_URL=https://example.supabase.co NEXT_PUBLIC_SUPABASE_ANON_KEY=dummy SUPABASE_SERVICE_ROLE_KEY=dummy npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a49a2a8cb8832cb65e100d4f7db152