### PR TITLE
Oppdater bucket-kommentar i upload-route

### DIFF
--- a/src/app/api/upload/route.ts
+++ b/src/app/api/upload/route.ts
@@ -195,7 +195,7 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Map type to bucket name (using the 6 buckets from Supabase)
+    // Map type to bucket name (using the 7 buckets from Supabase; `user` falls back to `stableimages`)
     const typeToBucketMap: Record<string, string> = {
       stable: "stableimages",
       box: "boximages", 


### PR DESCRIPTION
## Summary
- presiser at type-to-bucket map bruker syv buckets og at `user`-type faller tilbake til `stableimages`

## Testing
- `npm run lint`
- `CI=1 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a49d0ecae0832c9e97f8f5bf08ac24