### PR TITLE
Legg til Cypress-test for dashboard-faner

### DIFF
--- a/cypress/e2e/dashboard-tabs.cy.ts
+++ b/cypress/e2e/dashboard-tabs.cy.ts
@@ -1,0 +1,36 @@
+/// <reference types="cypress" />
+
+describe('Dashboard tabs', () => {
+  it('switcher mellom alle dashboard-faner', () => {
+    cy.login()
+
+    // Starter på Analyse
+    cy.get('[data-cy="analytics"]').should('be.visible')
+
+    // Mine staller
+    cy.get('[data-cy="dashboard-tab-stables"]').click()
+    cy.location('search').should('contain', 'tab=stables')
+    cy.get('[data-cy="stables"]').should('be.visible')
+
+    // Hest (salg av hest)
+    cy.get('[data-cy="dashboard-tab-horse-sales"]').click()
+    cy.location('search').should('contain', 'tab=horse-sales')
+    cy.get('[data-cy="horse-sales"]').should('be.visible')
+
+    // Tjenester
+    cy.get('[data-cy="dashboard-tab-services"]').click()
+    cy.location('search').should('contain', 'tab=services')
+    cy.get('[data-cy="services"]').should('be.visible')
+
+    // Fôrhest
+    cy.get('[data-cy="dashboard-tab-forhest"]').click()
+    cy.location('search').should('contain', 'tab=forhest')
+    cy.get('[data-cy="forhest"]').should('be.visible')
+
+    // Tilbake til Analyse
+    cy.get('[data-cy="dashboard-tab-analytics"]').click()
+    cy.location('search').should('contain', 'tab=analytics')
+    cy.get('[data-cy="analytics"]').should('be.visible')
+  })
+})
+


### PR DESCRIPTION
## Summary
- legg til Cypress-test som verifiserer navigering mellom fanene Analyse, Mine staller, Hest, Tjenester og Fôrhest på dashboardet

## Testing
- `npm run lint` *(fails: Found lockfile missing swc dependencies; ENETUNREACH)*
- `npm run build` *(fails: Found lockfile missing swc dependencies; Personal API key not provided)*
- `npm run test -- --spec cypress/e2e/dashboard-tabs.cy.ts` *(fails: dependency Xvfb missing)*

------
https://chatgpt.com/codex/tasks/task_e_68b17afd7568832cbf7d1a40416fa84a